### PR TITLE
Fix in android native null safety

### DIFF
--- a/android/src/main/kotlin/com/getmati/mati_plugin_flutter/MatiPluginFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/getmati/mati_plugin_flutter/MatiPluginFlutterPlugin.kt
@@ -29,7 +29,7 @@ class MatiPluginFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware 
     binding.addActivityResultListener { requestCode, resultCode, data ->
       if (requestCode == MetamapSdk.DEFAULT_REQUEST_CODE) {
         if (resultCode == Activity.RESULT_OK) {
-          val result = data.getStringExtra("ARG_VERIFICATION_ID") +" "+ data.getStringExtra("ARG_IDENTITY_ID")
+          val result = data?.getStringExtra("ARG_VERIFICATION_ID") +" "+ data?.getStringExtra("ARG_IDENTITY_ID")
           channel.invokeMethod("success", result)
         } else {
           channel.invokeMethod("cancelled", null)


### PR DESCRIPTION
This PR solve this error using flutter 3.0 and some android devices:

```
/mati_plugin_flutter-2.5.5/android/src/main/kotlin/com/getmati/mati_plugin_flutter/MatiPluginFlutterPlugin.kt: (32, 28): Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type Intent?
mati_plugin_flutter-2.5.5/android/src/main/kotlin/com/getmati/mati_plugin_flutter/MatiPluginFlutterPlugin.kt: (32, 77): Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type Intent?
```